### PR TITLE
[#139288729] add :service param to request handler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in royal_mail_api.gemspec
 gemspec
 
-gem 'pry'
+gem 'rspec'

--- a/lib/royal_mail_api/request_handler.rb
+++ b/lib/royal_mail_api/request_handler.rb
@@ -21,6 +21,7 @@ module RoyalMailApi
     end
 
     def build_xml(attrs={})
+      attrs[:service_code] = service_code(attrs[:service])
       XmlBuilder.new(request_name, attrs.merge(security_attrs), request_type).build
     end
 
@@ -73,6 +74,15 @@ module RoyalMailApi
           config.tracking_endpoint
         when 'shipping'
           config.shipping_endpoint
+      end
+    end
+
+    def service_code service
+      case service
+      when 'tracked'
+        'TPN'
+      when 'tracked_high_volume'
+        'TPM'
       end
     end
 

--- a/lib/royal_mail_api/version.rb
+++ b/lib/royal_mail_api/version.rb
@@ -1,3 +1,3 @@
 module RoyalMailApi
-  VERSION = "0.2.5"
+  VERSION = "0.3.0"
 end

--- a/lib/xml/create_shipment.xml
+++ b/lib/xml/create_shipment.xml
@@ -24,7 +24,7 @@
       <v2:serviceOffering>
         <serviceOfferingCode>
           <code>
-            TPN
+            <%= service_code %>
           </code>
         </serviceOfferingCode>
       </v2:serviceOffering>

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -10,7 +10,8 @@ describe 'Errors' do
       address_line1: '44-46 Morningside Road',
       post_town: 'Edinburgh',
       post_code: 'EH10 4BF',
-      weight: 900
+      weight: 900,
+      service: 'tracked'
     }
   }
 

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -12,7 +12,8 @@ describe RoyalMailApi::RequestHandler do
       address_line1: '44-46 Morningside Road',
       post_town: 'Edinburgh',
       post_code: 'EH10 4BF',
-      weight: 900
+      weight: 900,
+      service: 'tracked',
     }
   }
 
@@ -45,6 +46,23 @@ describe RoyalMailApi::RequestHandler do
 
       it "are converted to xml entity references" do
         expect(@response.http.code).to eq 200
+      end
+    end
+  end
+
+  describe "service code" do
+    let(:xml) { described_class.new(:create_shipment).build_xml(base_attrs) }
+
+    context "tracked service" do
+      it "uses the correct Royal Mail service code" do
+        expect(xml).to include 'TPN'
+      end
+    end
+
+    context "THV (Tracked High Volume) service" do
+      it "uses the correct Royal Mail service code" do
+        base_attrs[:service] = 'tracked_high_volume'
+        expect(xml).to include 'TPM'
       end
     end
   end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -10,7 +10,8 @@ describe RoyalMailApi::ResponseHandler do
       address_line1: '44-46 Morningside Road',
       post_town: 'Edinburgh',
       post_code: 'EH10 4BF',
-      weight: 900
+      weight: 900,
+      service: 'tracked',
     }
   }
 

--- a/spec/warnings_spec.rb
+++ b/spec/warnings_spec.rb
@@ -10,7 +10,8 @@ describe 'Warnings' do
       address_line1: '44-46 Morningside Road',
       post_town: 'Edinburgh',
       post_code: 'EH10 4BF',
-      weight: 900
+      weight: 900,
+      service: 'tracked',
     }
   } 
 
@@ -21,7 +22,7 @@ describe 'Warnings' do
       VCR.use_cassette("warnings") do
         response = RoyalMailApi::RequestHandler.request(:create_shipment, attrs)
         parsed_response = RoyalMailApi::ResponseHandler.handle_response(response)
-        expect(parsed_response.warnings.count).to eq 2
+        expect(parsed_response.warnings.count).to eq 1
         expect(parsed_response.warnings.first.description).to_not be nil
         expect(parsed_response.warnings.first.description).to_not be_empty
       end


### PR DESCRIPTION
takes argument 'tracked' or 'tracked_high_volume' and generates a :create_shipment request with the correct RM service code