### PR TITLE
Make config customizable per request instance

### DIFF
--- a/lib/royal_mail_api/request_handler.rb
+++ b/lib/royal_mail_api/request_handler.rb
@@ -4,6 +4,7 @@ module RoyalMailApi
       def request(request_name, attrs={})
         begin
           handler = RoyalMailApi::RequestHandler.new(request_name)
+          handler.configure(&block) if block_given?
           xml = handler.build_xml(attrs)
           handler.savon.call(request_name, xml: xml)
         rescue Savon::SOAPFault => e

--- a/lib/royal_mail_api/request_handler.rb
+++ b/lib/royal_mail_api/request_handler.rb
@@ -16,8 +16,16 @@ module RoyalMailApi
       end
     end
 
+    attr_accessor :config
+
     def initialize(request_name)
       @request_name = request_name
+
+      self.config = self.class.config.dup
+    end
+
+    def configure
+      yield config if block_given?
     end
 
     def build_xml(attrs={})
@@ -107,10 +115,6 @@ module RoyalMailApi
           nonce + creation_date + hashedpassword
         )
       }
-    end
-
-    def config
-      self.class.config
     end
   end
 end

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -27,14 +27,6 @@ describe RoyalMailApi::RequestHandler do
       end
     end
 
-    it 'yields the config object when passed a block' do
-      expect { |b| request(:create_shipment, attrs, &b) }.to yield_with_args(subject.config)
-    end
-
-    it 'does not yield the config object when not passed a block' do
-      expect { |b| request(:create_shipment, attrs) }.not_to yield_control
-    end
-
     describe '#create_shipment' do
       let(:attrs) { base_attrs }
       let(:default_cassette) { "create_shipment" }
@@ -81,7 +73,7 @@ describe RoyalMailApi::RequestHandler do
     subject { described_class.new(:create_shipment) }
 
     describe '#config' do
-      it 'creates a copy of the config object' do
+      it 'creates a copy of the master config object' do
         expect(subject.config).not_to eql(described_class.config)
       end
     end

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -66,4 +66,22 @@ describe RoyalMailApi::RequestHandler do
       end
     end
   end
+
+  context 'configuration' do
+    before { configure_client }
+
+    subject { described_class.new(:create_shipment) }
+
+    describe '#config' do
+      it 'creates a copy of the config object' do
+        expect(subject.config).not_to eql(described_class.config)
+      end
+    end
+
+    describe '#configure' do
+      it 'yields the config object' do
+        expect { |b| subject.configure(&b) }.to yield_with_args(subject.config)
+      end
+    end
+  end
 end

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -27,6 +27,14 @@ describe RoyalMailApi::RequestHandler do
       end
     end
 
+    it 'yields the config object when passed a block' do
+      expect { |b| request(:create_shipment, attrs, &b) }.to yield_with_args(subject.config)
+    end
+
+    it 'does not yield the config object when not passed a block' do
+      expect { |b| request(:create_shipment, attrs) }.not_to yield_control
+    end
+
     describe '#create_shipment' do
       let(:attrs) { base_attrs }
       let(:default_cassette) { "create_shipment" }


### PR DESCRIPTION
_Based on feature/get_multi_item_summary as master is currently not up to date_ ☹️

Make config customizable per request  instance. Example:

```ruby
RoyalMailApi::RequestHandler.request(:create_shipment, attrs) do |config|
  config.username = 'request-specific-username'
  config.password = 'request-specific-password'
end
```