### PR TITLE
[#158904413] nonce newline char

### DIFF
--- a/lib/royal_mail_api/request_handler.rb
+++ b/lib/royal_mail_api/request_handler.rb
@@ -111,7 +111,7 @@ module RoyalMailApi
         username: config.username,
         application_id: config.application_id,
         date_time_now: date_time_now,
-        encoded_nonce: Base64.encode64(nonce),
+        encoded_nonce: Base64.encode64(nonce).strip,
         password_digest: Digest::SHA1.base64digest(
           nonce + date_time_now + hashedpassword
         ),

--- a/lib/royal_mail_api/version.rb
+++ b/lib/royal_mail_api/version.rb
@@ -1,3 +1,3 @@
 module RoyalMailApi
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
`Base64.encode64(nonce)` adds a newline character to the end of the string. RM Pro API does not seem to like this very much.